### PR TITLE
Add Spring Security configuration and annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # demo-order-service
 
-This is a simple order processing and management microservice example in Java with Spring Boot.  Lots of things may be faked for demo purposes; I usually remember to add a comment where I do that.
+This is a code sample showing a simple order processing and management microservice example in Java with Spring Boot. Some things are mocked/faked for demo purposes and are called out in comments.
 
-This is just a demo for my "portfolio"; as such, no license is granted and no warranty or representation is made of fitness for real production use (i.e., you may not deploy this to your company's production environment).
+Imagine this is one of several microservices making up the backend of an online store. Other services might include a user account service, a login/authorization service (IdP), a payment service, a notification service, etc.
 
 ### Tech stack
 - Java 21
 - Spring Boot
 - PostgreSQL
 - Docker
+
+## Security
+
+This service uses Spring Security with JWT authentication. The access token is expected to be provided via an HTTP-only cookie set by an external login service. For non-browser clients, an Authorization: Bearer header is also supported as a fallback.
+
+- Method security is enabled; admin endpoints are protected with `@PreAuthorize("hasRole('ADMIN')")`.
+- Stateless API: no server-side sessions.
+- Actuator endpoints `/actuator/health`, `/actuator/info`, and `/actuator/metrics` are publicly accessible.
+- CSRF is disabled for this API service. When using cookies in a browser, ensure the login service sets tokens with `HttpOnly`, `Secure`, and an appropriate `SameSite` attribute to mitigate CSRF.

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,10 @@
     <packaging>jar</packaging>
     <description>Order processing and management service</description>
 
+    <properties>
+        <argLine/> <!-- This is needed for the mockito agent registration below -->
+    </properties>
+
     <dependencies>
         <!-- Shared Common Module -->
         <dependency>
@@ -47,6 +51,17 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- Spring Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <!-- OAuth2 Resource Server for JWT -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
 
         <!-- Resilience4j Circuit Breaker -->
@@ -82,16 +97,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>
@@ -110,6 +115,24 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>properties</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>@{argLine} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.cyclonedx</groupId>

--- a/src/main/java/org/example/order/config/CookieOrHeaderBearerTokenResolver.java
+++ b/src/main/java/org/example/order/config/CookieOrHeaderBearerTokenResolver.java
@@ -1,0 +1,51 @@
+package org.example.order.config;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.lang.Nullable;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
+import org.springframework.util.StringUtils;
+
+/**
+ * Resolves a Bearer token from an HttpOnly cookie first, then falls back to the Authorization header.
+ */
+class CookieOrHeaderBearerTokenResolver implements BearerTokenResolver {
+
+    private final String cookieName;
+    private final DefaultBearerTokenResolver headerResolver;
+
+    CookieOrHeaderBearerTokenResolver(String cookieName) {
+        this.cookieName = cookieName;
+        this.headerResolver = new DefaultBearerTokenResolver();
+        this.headerResolver.setAllowUriQueryParameter(false);
+    }
+
+    @Override
+    public String resolve(HttpServletRequest request) {
+        String fromCookie = resolveFromCookie(request, cookieName);
+        if (StringUtils.hasText(fromCookie)) {
+            String value = fromCookie.trim();
+            if (StringUtils.startsWithIgnoreCase(value, "Bearer ")) {
+                value = value.substring(7).trim();
+            }
+            return value;
+        }
+        return headerResolver.resolve(request);
+    }
+
+    @Nullable
+    private static String resolveFromCookie(HttpServletRequest request, String cookieName) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        for (Cookie c : cookies) {
+            if (cookieName.equals(c.getName())) {
+                String value = c.getValue();
+                return StringUtils.hasText(value) ? value : null;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/example/order/config/JwtProperties.java
+++ b/src/main/java/org/example/order/config/JwtProperties.java
@@ -1,0 +1,38 @@
+package org.example.order.config;
+
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "security.jwt")
+public class JwtProperties {
+
+    /**
+     * Name of the HttpOnly cookie that carries the JWT access token.
+     */
+    @NotBlank
+    private String cookieName = "auth_token"; // sensible default; override in properties
+
+    /**
+     * Secret used to validate HMAC-signed (HS256) JWTs. Prefer Base64-encoded value via env var.
+     */
+    @NotBlank
+    private String secret;
+
+    public String getCookieName() {
+        return cookieName;
+    }
+
+    public void setCookieName(String cookieName) {
+        this.cookieName = cookieName;
+    }
+
+    public String getSecret() {
+        return secret;
+    }
+
+    public void setSecret(String secret) {
+        this.secret = secret;
+    }
+}

--- a/src/main/java/org/example/order/config/RestTemplateConfig.java
+++ b/src/main/java/org/example/order/config/RestTemplateConfig.java
@@ -93,7 +93,6 @@ public class RestTemplateConfig {
     public Retry productServiceRetry() {
         RetryConfig config = RetryConfig.custom()
                 .maxAttempts(3)
-                .waitDuration(Duration.ofSeconds(1))
                 .intervalFunction(exponentialBackoffInterval())
                 .retryOnException(throwable -> 
                     throwable instanceof org.springframework.web.client.ResourceAccessException ||
@@ -110,7 +109,6 @@ public class RestTemplateConfig {
     public Retry paymentServiceRetry() {
         RetryConfig config = RetryConfig.custom()
                 .maxAttempts(2) // Fewer retries for payment operations
-                .waitDuration(Duration.ofSeconds(2))
                 .intervalFunction(exponentialBackoffInterval())
                 .retryOnException(throwable -> 
                     throwable instanceof org.springframework.web.client.ResourceAccessException)
@@ -126,7 +124,6 @@ public class RestTemplateConfig {
     public Retry notificationServiceRetry() {
         RetryConfig config = RetryConfig.custom()
                 .maxAttempts(4) // More retries for notifications
-                .waitDuration(Duration.ofMillis(500))
                 .intervalFunction(exponentialBackoffInterval())
                 .retryOnException(throwable -> 
                     throwable instanceof org.springframework.web.client.ResourceAccessException ||

--- a/src/main/java/org/example/order/config/SecurityConfig.java
+++ b/src/main/java/org/example/order/config/SecurityConfig.java
@@ -1,0 +1,104 @@
+package org.example.order.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.web.SecurityFilterChain;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * Security configuration for the Order Service.
+ * - Enables method-level security to enforce @PreAuthorize annotations
+ * - Switches to JWT auth via HttpOnly cookie (stateless)
+ * - Exposes only essential actuator endpoints without authentication
+ */
+@Configuration
+@EnableMethodSecurity
+@EnableConfigurationProperties(JwtProperties.class)
+class SecurityConfig {
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http,
+                                            BearerTokenResolver bearerTokenResolver,
+                                            JwtDecoder jwtDecoder) throws Exception {
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .authorizeHttpRequests(auth -> auth
+                .requestMatchers("/actuator/health", "/actuator/info", "/actuator/metrics").permitAll()
+                .anyRequest().authenticated()
+            )
+            .oauth2ResourceServer(oauth2 -> oauth2
+                .bearerTokenResolver(bearerTokenResolver)
+                .jwt(jwt -> jwt
+                    .decoder(jwtDecoder)
+                    .jwtAuthenticationConverter(jwtAuthenticationConverter())
+                )
+            );
+
+        return http.build();
+    }
+
+    @Bean
+    BearerTokenResolver bearerTokenResolver(JwtProperties props) {
+        return new CookieOrHeaderBearerTokenResolver(props.getCookieName());
+    }
+
+    @Bean
+    JwtDecoder jwtDecoder(JwtProperties props) {
+        var key = new SecretKeySpec(props.getSecret().getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+        return NimbusJwtDecoder
+                .withSecretKey(key)
+                .macAlgorithm(MacAlgorithm.HS256)
+                .build();
+    }
+
+    private JwtAuthenticationConverter jwtAuthenticationConverter() {
+        JwtGrantedAuthoritiesConverter rolesConverter = new JwtGrantedAuthoritiesConverter();
+        rolesConverter.setAuthoritiesClaimName("roles");
+        rolesConverter.setAuthorityPrefix("ROLE_");
+
+        JwtGrantedAuthoritiesConverter scopeConverter = new JwtGrantedAuthoritiesConverter();
+        scopeConverter.setAuthoritiesClaimName("scope");
+        scopeConverter.setAuthorityPrefix("SCOPE_");
+
+        Converter<Jwt, Collection<GrantedAuthority>> combined = jwt -> {
+            List<GrantedAuthority> authorities = new ArrayList<>();
+            Collection<GrantedAuthority> roleAuth = rolesConverter.convert(jwt);
+            if (roleAuth != null) authorities.addAll(roleAuth);
+            Collection<GrantedAuthority> scopeAuth = scopeConverter.convert(jwt);
+            if (scopeAuth != null) authorities.addAll(scopeAuth);
+            Object authClaim = jwt.getClaim("authorities");
+            if (authClaim instanceof Collection<?> col) {
+                for (Object val : col) {
+                    if (val != null) {
+                        authorities.add(new org.springframework.security.core.authority.SimpleGrantedAuthority(val.toString()));
+                    }
+                }
+            }
+            return authorities;
+        };
+
+        JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+        converter.setJwtGrantedAuthoritiesConverter(combined);
+        return converter;
+    }
+}

--- a/src/main/java/org/example/order/controller/OrderController.java
+++ b/src/main/java/org/example/order/controller/OrderController.java
@@ -14,6 +14,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -105,6 +106,7 @@ class OrderController {
     /**
      * Get orders for a specific user (admin endpoint)
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/user/{userId}")
     ResponseEntity<Page<OrderResponse>> getOrdersForUser(
             @PathVariable UUID userId,
@@ -120,6 +122,7 @@ class OrderController {
     /**
      * Get orders by status
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/status/{status}")
     ResponseEntity<Page<OrderResponse>> getOrdersByStatus(
             @PathVariable OrderStatus status,
@@ -147,6 +150,7 @@ class OrderController {
     /**
      * Update order status
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/{id}/status")
     ResponseEntity<OrderResponse> updateOrderStatus(@PathVariable UUID id,
                                                    @RequestParam OrderStatus status) {
@@ -170,6 +174,7 @@ class OrderController {
     /**
      * Get orders that need processing
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/processing-queue")
     ResponseEntity<List<OrderResponse>> getOrdersForProcessing() {
         logger.info("Received request to get orders for processing");
@@ -181,6 +186,7 @@ class OrderController {
     /**
      * Get overdue orders
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/overdue")
     ResponseEntity<List<OrderResponse>> getOverdueOrders(
             @RequestParam(defaultValue = "24") int hoursOverdue) {
@@ -193,6 +199,7 @@ class OrderController {
     /**
      * Get order statistics
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/statistics")
     ResponseEntity<OrderService.OrderStatistics> getOrderStatistics() {
         logger.info("Received request to get order statistics");
@@ -204,6 +211,7 @@ class OrderController {
     /**
      * Get daily order count
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/statistics/daily-count")
     ResponseEntity<Long> getDailyOrderCount() {
         logger.info("Received request to get daily order count");
@@ -215,6 +223,7 @@ class OrderController {
     /**
      * Get total sales amount for date range
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/statistics/sales")
     ResponseEntity<BigDecimal> getTotalSalesAmount(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startDate,
@@ -228,6 +237,7 @@ class OrderController {
     /**
      * Get orders by date range
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @GetMapping("/date-range")
     ResponseEntity<Page<OrderResponse>> getOrdersByDateRange(
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) Instant startDate,
@@ -293,6 +303,7 @@ class OrderController {
     /**
      * Bulk update order status (admin endpoint)
      */
+    @PreAuthorize("hasRole('ADMIN')")
     @PatchMapping("/bulk-status-update")
     ResponseEntity<BulkUpdateResult> bulkUpdateOrderStatus(
             @RequestBody BulkStatusUpdateRequest request) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+# Actuator
+management.endpoints.web.exposure.include=health,info,metrics
+
+# JPA Open Session in View should be disabled (per guidelines)
+spring.jpa.open-in-view=false
+
+# Security - JWT via HttpOnly cookie (configured via env vars in real environments)
+# Name of the cookie that carries the JWT access token
+security.jwt.cookie-name=${SECURITY_JWT_COOKIE_NAME:auth_token}
+# HMAC secret for verifying JWTs (HS256). Use a strong value via SECURITY_JWT_SECRET env var in non-dev environments.
+security.jwt.secret=${SECURITY_JWT_SECRET:local-dev-very-long-secret-not-for-prod}

--- a/src/test/java/org/example/order/config/SecurityConfigTest.java
+++ b/src/test/java/org/example/order/config/SecurityConfigTest.java
@@ -1,0 +1,65 @@
+package org.example.order.config;
+
+import org.example.order.service.OrderService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * SpringBootTest-based validation of security beans and token resolution behavior.
+ */
+@SpringBootTest(properties = {
+        // Exclude DB/JPA/Flyway to avoid requiring a datasource
+        "spring.autoconfigure.exclude=" +
+                "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration",
+        // Provide required JWT properties (HS256 requires >= 256-bit secret)
+        "security.jwt.secret=0123456789ABCDEF0123456789ABCDEF",
+        "security.jwt.cookie-name=auth_token"
+})
+class SecurityConfigTest {
+
+    @Autowired
+    private SecurityFilterChain securityFilterChain;
+
+    @Autowired
+    private BearerTokenResolver bearerTokenResolver;
+
+    @MockitoBean
+    private OrderService orderService; // needed for the Spring context
+
+    @Test
+    @DisplayName("SecurityFilterChain bean is created and BearerTokenResolver is our cookie-first resolver")
+    void contextLoadsAndBeansPresent() {
+        assertThat(securityFilterChain).isNotNull();
+        assertThat(bearerTokenResolver).isInstanceOf(CookieOrHeaderBearerTokenResolver.class);
+    }
+
+    @Test
+    @DisplayName("BearerTokenResolver resolves from cookie first, else falls back to Authorization header")
+    void cookieFirstThenHeader() {
+        // Cookie preferred
+        MockHttpServletRequest req1 = new MockHttpServletRequest();
+        req1.setCookies(new jakarta.servlet.http.Cookie("auth_token", "Bearer cookie-token"));
+        assertThat(bearerTokenResolver.resolve(req1)).isEqualTo("cookie-token");
+
+        // Header fallback
+        MockHttpServletRequest req2 = new MockHttpServletRequest();
+        req2.addHeader("Authorization", "Bearer header-token");
+        assertThat(bearerTokenResolver.resolve(req2)).isEqualTo("header-token");
+
+        // Empty cookie -> header
+        MockHttpServletRequest req3 = new MockHttpServletRequest();
+        req3.setCookies(new jakarta.servlet.http.Cookie("auth_token", " "));
+        req3.addHeader("Authorization", "Bearer h2");
+        assertThat(bearerTokenResolver.resolve(req3)).isEqualTo("h2");
+    }
+}

--- a/src/test/java/org/example/order/config/TestSecurityExceptionHandler.java
+++ b/src/test/java/org/example/order/config/TestSecurityExceptionHandler.java
@@ -1,0 +1,27 @@
+package org.example.order.config;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Test-scoped exception handler to ensure security exceptions are translated
+ * to proper HTTP status codes during SpringBootTest execution.
+ * This class lives under src/test/java and does not affect production code.
+ */
+@RestControllerAdvice
+class TestSecurityExceptionHandler {
+
+    @ExceptionHandler(AccessDeniedException.class)
+    ResponseEntity<Void> handleAccessDenied(AccessDeniedException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+
+    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+    ResponseEntity<Void> handleAuthMissing(AuthenticationCredentialsNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
+}

--- a/src/test/java/org/example/order/controller/OrderControllerSecurityTest.java
+++ b/src/test/java/org/example/order/controller/OrderControllerSecurityTest.java
@@ -1,0 +1,229 @@
+package org.example.order.controller;
+
+import jakarta.servlet.http.Cookie;
+import org.example.order.domain.OrderStatus;
+import org.example.order.dto.OrderResponse;
+import org.example.order.service.OrderService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * SpringBootTest-based security validation that exercises the real security configuration
+ * (JWT via HttpOnly cookie) and verifies endpoint access control without using reflection.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK, properties = {
+        // Exclude DB/Flyway to avoid requiring a datasource in tests
+        "spring.autoconfigure.exclude=" +
+                "org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration," +
+                "org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration",
+        // Provide required JWT properties (HS256 requires >= 256-bit secret)
+        "security.jwt.secret=0123456789ABCDEF0123456789ABCDEF",
+        "security.jwt.cookie-name=auth_token"
+})
+@AutoConfigureMockMvc
+class OrderControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private JwtDecoder jwtDecoder;
+
+    @MockitoBean
+    private OrderService orderService;
+
+    private Jwt jwtWithRoles(String token, String... roles) {
+        Instant now = Instant.now();
+        return new Jwt(
+                token,
+                now,
+                now.plusSeconds(600),
+                Map.of("alg", "HS256"),
+                Map.of(
+                        "sub", "user@example.com",
+                        "roles", List.of((Object[]) roles)
+                )
+        );
+    }
+
+    private Cookie authCookie(String token) {
+        Cookie c = new Cookie("auth_token", token);
+        c.setHttpOnly(true);
+        return c;
+    }
+
+    @BeforeEach
+    void setupStubs() {
+        when(orderService.getOrdersForUser(any(UUID.class), any(Pageable.class)))
+                .thenAnswer(inv -> Page.empty(PageRequest.of(0, 1)));
+        when(orderService.getOrdersByStatus(any(OrderStatus.class), any(Pageable.class)))
+                .thenAnswer(inv -> Page.empty(PageRequest.of(0, 1)));
+        when(orderService.updateOrderStatus(any(UUID.class), any(OrderStatus.class)))
+                .thenReturn(new OrderResponse(null, null, null, OrderStatus.CONFIRMED, BigDecimal.ZERO,
+                        null, null, null, 0, 0, null, null));
+        when(orderService.getOrdersForProcessing()).thenReturn(List.of());
+        when(orderService.getOverdueOrders(anyInt())).thenReturn(List.of());
+        when(orderService.getOrderStatistics()).thenReturn(new OrderService.OrderStatistics(0, BigDecimal.ZERO, List.of()));
+        when(orderService.getDailyOrderCount()).thenReturn(0L);
+        when(orderService.getTotalSalesAmount(any(Instant.class), any(Instant.class))).thenReturn(BigDecimal.ZERO);
+    }
+
+    @Test
+    @DisplayName("Unauthenticated requests to admin endpoints return 401")
+    void unauthenticatedRequestsReturn401() throws Exception {
+        UUID uid = UUID.randomUUID();
+        UUID oid = UUID.randomUUID();
+        String start = "2025-01-01T00:00:00Z";
+        String end = "2025-01-02T00:00:00Z";
+
+        mockMvc.perform(get("/api/v1/orders/processing-queue"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/v1/orders/user/" + uid).param("page", "0").param("size", "1"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/v1/orders/status/CONFIRMED").param("page", "0").param("size", "1"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(patch("/api/v1/orders/" + oid + "/status").param("status", "CONFIRMED"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/v1/orders/overdue").param("hoursOverdue", "24"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/v1/orders/statistics"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/v1/orders/statistics/daily-count"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/v1/orders/statistics/sales").param("startDate", start).param("endDate", end))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/v1/orders/date-range").param("startDate", start).param("endDate", end).param("page", "0").param("size", "1"))
+                .andExpect(status().isUnauthorized());
+
+        String bulkJson = "{\"orderIds\":[\"" + UUID.randomUUID() + "\"],\"newStatus\":\"CONFIRMED\"}";
+        mockMvc.perform(patch("/api/v1/orders/bulk-status-update").contentType(MediaType.APPLICATION_JSON).content(bulkJson))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Non-admin users receive 403 on admin endpoints")
+    void userRoleGetsForbiddenOnAdminEndpoints() throws Exception {
+        String token = "user-token";
+        when(jwtDecoder.decode(token)).thenReturn(jwtWithRoles(token, "USER"));
+
+        UUID uid = UUID.randomUUID();
+        UUID oid = UUID.randomUUID();
+        String start = "2025-01-01T00:00:00Z";
+        String end = "2025-01-02T00:00:00Z";
+
+        mockMvc.perform(get("/api/v1/orders/processing-queue").cookie(authCookie(token)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/v1/orders/user/" + uid).param("page", "0").param("size", "1").cookie(authCookie(token)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/v1/orders/status/CONFIRMED").param("page", "0").param("size", "1").cookie(authCookie(token)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(patch("/api/v1/orders/" + oid + "/status").param("status", "CONFIRMED").cookie(authCookie(token)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/v1/orders/overdue").param("hoursOverdue", "24").cookie(authCookie(token)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/v1/orders/statistics").cookie(authCookie(token)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/v1/orders/statistics/daily-count").cookie(authCookie(token)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/v1/orders/statistics/sales").param("startDate", start).param("endDate", end).cookie(authCookie(token)))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/v1/orders/date-range").param("startDate", start).param("endDate", end).param("page", "0").param("size", "1").cookie(authCookie(token)))
+                .andExpect(status().isForbidden());
+
+        String bulkJson = "{\"orderIds\":[\"" + UUID.randomUUID() + "\"],\"newStatus\":\"CONFIRMED\"}";
+        mockMvc.perform(patch("/api/v1/orders/bulk-status-update").contentType(MediaType.APPLICATION_JSON).content(bulkJson).cookie(authCookie(token)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("Admin users can access all admin endpoints")
+    void adminRoleCanAccessAdminEndpoints() throws Exception {
+        String token = "admin-token";
+        when(jwtDecoder.decode(token)).thenReturn(jwtWithRoles(token, "ADMIN"));
+
+        UUID uid = UUID.randomUUID();
+        UUID oid = UUID.randomUUID();
+        String start = "2025-01-01T00:00:00Z";
+        String end = "2025-01-02T00:00:00Z";
+
+        mockMvc.perform(get("/api/v1/orders/processing-queue").cookie(authCookie(token)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/orders/user/" + uid).param("page", "0").param("size", "1").cookie(authCookie(token)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/orders/status/CONFIRMED").param("page", "0").param("size", "1").cookie(authCookie(token)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(patch("/api/v1/orders/" + oid + "/status").param("status", "CONFIRMED").cookie(authCookie(token)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/orders/overdue").param("hoursOverdue", "24").cookie(authCookie(token)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/orders/statistics").cookie(authCookie(token)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/orders/statistics/daily-count").cookie(authCookie(token)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/orders/statistics/sales").param("startDate", start).param("endDate", end).cookie(authCookie(token)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(get("/api/v1/orders/date-range").param("startDate", start).param("endDate", end).param("page", "0").param("size", "1").cookie(authCookie(token)))
+                .andExpect(status().isOk());
+
+        String bulkJson = "{\"orderIds\":[\"" + UUID.randomUUID() + "\"],\"newStatus\":\"CONFIRMED\"}";
+        mockMvc.perform(patch("/api/v1/orders/bulk-status-update").contentType(MediaType.APPLICATION_JSON).content(bulkJson).cookie(authCookie(token)))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Actuator health endpoint is public")
+    void actuatorHealthIsPublic() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
Add Spring Security configuration and annotations. Annotate endpoints that should be admin-only with PreAuthorize to ensure only admin users have access. Add tests to validate the security configuration. Remove testcontainers dependencies since there aren't integration tests. Configure mockito as a java-agent for surefire.